### PR TITLE
Add current music to queue command, show messages to everyone

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bot-musica-poc",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/v2/bot.ts
+++ b/src/v2/bot.ts
@@ -1,7 +1,7 @@
 import { CacheType, Client, Events, GatewayIntentBits, Guild, Interaction } from "discord.js";
 import { BOT_TOKEN } from "./config";
 import { commandDispatcher, setupCommands } from "./commands";
-import { BotQueue } from "./logic/queue";
+import { MusicQueue } from "./logic/queue";
 import { Player } from "./player";
 
 const bot = new Client({ intents: [GatewayIntentBits.Guilds, GatewayIntentBits.GuildVoiceStates] });
@@ -15,7 +15,7 @@ bot.on('guildCreate', async ({ id, name }: Guild) => {
     console.log(`Commands set in ${name}`);
 })
 
-const queue = new BotQueue();
+const queue = new MusicQueue();
 const player = new Player(queue, bot);
 
 bot.on(Events.InteractionCreate, (interaction: Interaction<CacheType>) => {

--- a/src/v2/commands/index.ts
+++ b/src/v2/commands/index.ts
@@ -1,14 +1,14 @@
 import { BOT_CLIENT_ID, BOT_TOKEN } from '../config';
 import { ChatInputCommandInteraction, Client, REST, Routes, SlashCommandBuilder } from "discord.js"
 import { playCommand } from "./play";
-import { BotQueue } from '../logic/queue';
+import { MusicQueue } from '../logic/queue';
 import { Player } from '../player';
 import { skipCommand } from './skip';
 import { queueCommand } from './queue';
 
 type HandlerParams = {
     interaction: ChatInputCommandInteraction,
-    queue: BotQueue,
+    queue: MusicQueue,
     bot: Client,
     player: Player
 }

--- a/src/v2/commands/play.ts
+++ b/src/v2/commands/play.ts
@@ -33,7 +33,7 @@ export const playCommand: BotCommand = {
                 name: searchResult.title,
                 youtube_url: searchResult.url,
                 seconds: searchResult.duration.seconds,
-                added_by: interaction.user
+                added_by: interaction.user.id
             });
 
             if (player.playMusic(guildId)) {

--- a/src/v2/commands/play.ts
+++ b/src/v2/commands/play.ts
@@ -1,6 +1,7 @@
 import { ChatInputCommandInteraction, GuildMember, SlashCommandBuilder, SlashCommandStringOption } from "discord.js";
 import { BotCommand } from ".";
 import { searchYT } from "../search";
+import { userToMention } from "../util";
 
 const voiceChannelFromInteraction = (interaction: ChatInputCommandInteraction) => {
     const member = interaction.member as GuildMember;
@@ -26,17 +27,22 @@ export const playCommand: BotCommand = {
 
         const query = interaction.options.getString('query')!;
         const searchResult = await searchYT(query);
+        const mention = userToMention(interaction.user);
         if (searchResult) {
-            queue.enqueueMusic(guildId, voiceChannel.id, {
+            queue.add(guildId, voiceChannel.id, {
                 name: searchResult.title,
                 youtube_url: searchResult.url,
-                seconds: searchResult.duration.seconds
-            })
+                seconds: searchResult.duration.seconds,
+                added_by: interaction.user
+            });
+
             if (player.playMusic(guildId)) {
-                interaction.followUp(`🎵  Now playing "${searchResult.title}"!`);
+                interaction.followUp(`✅ Done`);
+                interaction.channel?.send(`🎵 Now playing "${searchResult.title}", added by ${mention}.`);
             }
             else {
-                interaction.followUp(`🎵  Added "${searchResult.title}" to the queue!`);
+                interaction.followUp(`✅ Done`);
+                interaction.channel?.send(`🎵 "${searchResult.title}" was added to the queue by ${mention}.`);
             }
         }
         else {

--- a/src/v2/logic/queue.ts
+++ b/src/v2/logic/queue.ts
@@ -1,10 +1,8 @@
-import { User } from "discord.js";
-
 export type Music = {
     name: string;
     youtube_url: string;
     seconds: number;
-    added_by: User
+    added_by: string
 }
 
 type State = {
@@ -51,16 +49,19 @@ export class MusicQueue {
     }
 
     pop(guildId: string): { music: Music, channelId: string } | undefined {
-        if (!this.state[guildId] || !this.state[guildId].musics.length)
+        if (!this.state[guildId])
             return;
 
         const state = this.state[guildId];
-        const music = state.musics.slice(-1)[0];
+        const music = state.musics[0];
         Object.assign(state, {
             nowPlaying: music,
-            musics: state.musics.slice(0, state.musics.length - 1)
+            musics: state.musics.slice(1)
         });
 
+        if(!music)
+            return;
+        
         return {
             music: music,
             channelId: state.channelId

--- a/src/v2/logic/queue.ts
+++ b/src/v2/logic/queue.ts
@@ -1,17 +1,21 @@
+import { User } from "discord.js";
+
 export type Music = {
     name: string;
     youtube_url: string;
     seconds: number;
+    added_by: User
 }
 
 type State = {
     [guildId: string]: {
         channelId: string,
+        nowPlaying?: Music,
         musics: Music[]
     }
 }
 
-export class BotQueue {
+export class MusicQueue {
     state: State = {};
 
     constructor() {
@@ -22,28 +26,44 @@ export class BotQueue {
         return !this.state[guildId] || this.state[guildId]!.musics.length == 0;
     }
 
-    queue = (guild: string) => this.state[guild]?.musics || [];
+    queue = (guild: string): Music[] => {
+        const state = this.state[guild];
+        if (!state)
+            return [];
 
-    enqueueMusic(guildId: string, channelId: string, music: Music) {
-        if (!this.state[guildId]) {
-            this.state[guildId] = {
-                channelId,
-                musics: [music]
-            }
-        }
-        else {
-            this.state[guildId].channelId = channelId;
-            this.state[guildId].musics.push(music);
-        }
+        if (state.nowPlaying)
+            return [state.nowPlaying, ...state.musics]
+
+        return state.musics;
     }
 
-    popMusic(guildId: string) {
-        if (this.state[guildId]) {
-            return {
-                music: this.state[guildId].musics.shift(),
-                channelId: this.state[guildId].channelId
-            };
-        }
-        return {};
+    add(guildId: string, channelId: string, music: Music) {
+        if (!this.state[guildId])
+            this.state[guildId] = {
+                channelId,
+                musics: []
+            }
+
+        let state = { ...this.state[guildId] };
+        state.channelId = channelId;
+        state.musics.push(music);
+        Object.assign(this.state[guildId], state);
+    }
+
+    pop(guildId: string): { music: Music, channelId: string } | undefined {
+        if (!this.state[guildId] || !this.state[guildId].musics.length)
+            return;
+
+        const state = this.state[guildId];
+        const music = state.musics.slice(-1)[0];
+        Object.assign(state, {
+            nowPlaying: music,
+            musics: state.musics.slice(0, state.musics.length - 1)
+        });
+
+        return {
+            music: music,
+            channelId: state.channelId
+        };
     }
 }

--- a/src/v2/search/search-process.ts
+++ b/src/v2/search/search-process.ts
@@ -7,4 +7,4 @@ process.on('message', async (search: string) => {
 
         process.send!({ type: 'search-success', data: r?.videos || [] })
     })
-})
+});

--- a/src/v2/util.ts
+++ b/src/v2/util.ts
@@ -1,0 +1,3 @@
+import { User } from "discord.js";
+
+export const userToMention = (user: User) => `<@${user.id}>`


### PR DESCRIPTION
When someone adds something to the music queue the message annoucing it is being shown only for the user that added the music, also the /queue command is not showing the current music.

- Show current music in /queue command
- Announce to everyone when a music is added to the queue